### PR TITLE
Refine search, motion, and responsive feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,8 @@ import { backend, isDesktop } from "./backend";
 import { ConfigSourcePanel } from "./components/ConfigSourcePanel";
 import { BackgroundImageEditor } from "./components/BackgroundImageEditor";
 import { ConfigGraphPanel } from "./components/ConfigGraphPanel";
+import { Disclosure } from "./components/Disclosure";
+import { Presence } from "./components/Presence";
 import { ReviewPanel } from "./components/ReviewPanel";
 import { ReferenceSettingRow } from "./components/ReferenceSettingRow";
 import { SetupPage } from "./components/SetupPage";
@@ -1945,6 +1947,13 @@ export default function App() {
 
   const platform = environment?.platform.toLocaleLowerCase() ?? "";
   const primaryModifier = platform.includes("mac") ? "⌘" : "Ctrl";
+  const searchLabel = text("搜索名称或 Ghostty 配置项", "Search names or Ghostty keys");
+  const reloadLabel = refreshing
+    ? text("正在重新读取 Ghostty 配置…", "Reloading Ghostty configuration…")
+    : text("重新读取 Ghostty 配置", "Reload Ghostty configuration");
+  const connectionLabel = isDesktop
+    ? `Ghostty ${environment?.ghostty.version ?? text("未找到", "Not found")}`
+    : text("试用模式", "Try mode");
 
   const selectCategory = (nextCategory: string) => {
     setCategory(nextCategory);
@@ -2039,8 +2048,8 @@ export default function App() {
                 setSearch("");
               }
             }}
-            placeholder={text("搜索设置", "Search settings")}
-            aria-label={text("搜索设置", "Search settings")}
+            placeholder={searchLabel}
+            aria-label={searchLabel}
             aria-keyshortcuts="Meta+K Control+K"
             aria-describedby={search ? "search-result-count" : undefined}
           />
@@ -2156,17 +2165,24 @@ export default function App() {
             <button
               type="button"
               className="toolbar-icon"
-              aria-label={text("重新读取 Ghostty 配置", "Reload Ghostty configuration")}
-              title={text("重新读取", "Reload")}
+              aria-label={reloadLabel}
+              aria-busy={refreshing}
+              title={reloadLabel}
               onClick={() => void refreshWorkspace(true)}
               disabled={refreshing || applying || switchingCandidateId !== null}
             >
               <RefreshCw size={15} className={refreshing ? "spin" : ""} />
             </button>
-            <span className={`connection-state connection-state--${workspaceSummary.state}`}>
-              <i /><span>{isDesktop
-                ? `Ghostty ${environment?.ghostty.version ?? text("未找到", "Not found")}`
-                : text("试用模式", "Try mode")}</span>
+            <span
+              className={`connection-state connection-state--${workspaceSummary.state}`}
+              role="status"
+              aria-label={connectionLabel}
+              title={connectionLabel}
+            >
+              <i /><span aria-hidden="true">{connectionLabel}</span>
+            </span>
+            <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+              {refreshing ? reloadLabel : ""}
             </span>
           </div>
         </header>
@@ -2224,13 +2240,17 @@ export default function App() {
                 )}
 
                 {showPreview && (
-                  <details className="inline-preview">
-                    <summary>{text("显示外观预览", "Show appearance preview")}</summary>
+                  <Disclosure
+                    className="inline-preview"
+                    summary={<><ChevronRight size={13} /> {text("显示外观预览", "Show appearance preview")}</>}
+                    summaryLabel={text("显示或隐藏外观预览", "Show or hide appearance preview")}
+                    bodyClassName="inline-preview__body"
+                  >
                     <TerminalPreview
                       values={previewMode === "draft" ? previewValues : savedPreviewValues}
                       backgroundImage={previewMode === "draft" ? draftBackgroundPreview : savedBackgroundPreview}
                     />
-                  </details>
+                  </Disclosure>
                 )}
 
                 {showBackgroundEditor && (
@@ -2333,7 +2353,11 @@ export default function App() {
                   <div className="empty-state">
                     <Search size={22} />
                     <strong>{search
-                      ? text("没有找到相关设置", "No matching settings")
+                      ? text(
+                          "没有找到与“{query}”相关的设置",
+                          "No settings found for “{query}”",
+                          { query: search },
+                        )
                       : category === "configured"
                         ? text("这份文件还没有设置项目", "This file has no configured settings yet")
                         : text("这里暂时没有可调整的设置", "No editable settings are available here yet")}</strong>
@@ -2388,107 +2412,112 @@ export default function App() {
           </div>
         )}
 
-        {session && changes.length > 0 && (
-          <section className={`draft-dock ${showPreview ? "draft-dock--settings-column" : ""}`} aria-label={text("未保存的修改", "Unsaved changes")}>
-            <div role="status" aria-live="polite">
-              <span className="draft-dot" />
-              <strong>{text(
-                "{count} 项修改尚未保存",
-                "{count} unsaved {noun}",
-                { count: changes.length, noun: changes.length === 1 ? "change" : "changes" },
-              )}</strong>
-            </div>
-            <div className="draft-dock__actions">
-              <button type="button" className="button button--secondary" onClick={resetAllDraft} disabled={refreshing || applying || switchingCandidateId !== null || restoringSnapshotId !== null}>
-                <RotateCcw size={14} /> {text("放弃修改", "Discard")}
-              </button>
+        <Presence show={Boolean(session && changes.length > 0)} className="draft-presence">
+          {session && (
+            <section className={`draft-dock ${showPreview ? "draft-dock--settings-column" : ""}`} aria-label={text("未保存的修改", "Unsaved changes")}>
+              <div role="status" aria-live="polite">
+                <span className="draft-dot" />
+                <strong>{text(
+                  "{count} 项修改尚未保存",
+                  "{count} unsaved {noun}",
+                  { count: changes.length, noun: changes.length === 1 ? "change" : "changes" },
+                )}</strong>
+              </div>
+              <div className="draft-dock__actions">
+                <button type="button" className="button button--secondary" onClick={resetAllDraft} disabled={refreshing || applying || switchingCandidateId !== null || restoringSnapshotId !== null}>
+                  <RotateCcw size={14} /> {text("放弃修改", "Discard")}
+                </button>
+                <button
+                  type="button"
+                  className="button button--primary"
+                  onClick={() => void openReview()}
+                  disabled={refreshing || reviewLoading || applying || switchingCandidateId !== null || restoringSnapshotId !== null}
+                >
+                  {reviewLoading ? text("正在检查…", "Checking…") : isDesktop ? text("检查并保存", "Review & save") : text("查看更改", "Review changes")}
+                  <kbd>{primaryModifier}S</kbd>
+                </button>
+              </div>
+            </section>
+          )}
+        </Presence>
+
+        <Presence show={Boolean(notice)} className="toast-presence">
+          {notice && (
+            <div className="save-toast">
+              <CheckCircle2 size={17} />
+              <span role="status" aria-live="polite">{notice}</span>
+              {discardedDraft && (
+                <button type="button" className="save-toast__action" onClick={undoDiscardedDraft}>
+                  {text("撤销", "Undo")}
+                </button>
+              )}
               <button
                 type="button"
-                className="button button--primary"
-                onClick={() => void openReview()}
-                disabled={refreshing || reviewLoading || applying || switchingCandidateId !== null || restoringSnapshotId !== null}
+                aria-label={text("关闭提示", "Dismiss message")}
+                onClick={() => {
+                  setNotice(null);
+                  setDiscardedDraft(null);
+                }}
               >
-                {reviewLoading ? text("正在检查…", "Checking…") : isDesktop ? text("检查并保存", "Review & save") : text("查看更改", "Review changes")}
-                <kbd>{primaryModifier}S</kbd>
+                <X size={14} />
               </button>
             </div>
-          </section>
-        )}
-
-        {notice && (
-          <div className="save-toast">
-            <CheckCircle2 size={17} />
-            <span role="status" aria-live="polite">{notice}</span>
-            {discardedDraft && (
-              <button type="button" className="save-toast__action" onClick={undoDiscardedDraft}>
-                {text("撤销", "Undo")}
-              </button>
-            )}
-            <button
-              type="button"
-              aria-label={text("关闭提示", "Dismiss message")}
-              onClick={() => {
-                setNotice(null);
-                setDiscardedDraft(null);
-              }}
-            >
-              <X size={14} />
-            </button>
-          </div>
-        )}
+          )}
+        </Presence>
       </main>
 
-      {reviewOpen && (
-        <ReviewPanel
-          changes={changes}
-          preview={changePreview}
-          loading={reviewLoading}
-          applying={applying}
-          busy={switchingCandidateId !== null || restoringSnapshotId !== null}
-          canRecover={reviewCanRecover}
-          readOnly={session?.readOnly ?? true}
-          targetLabel={activeCandidate?.label}
-          previewOnly={!isDesktop}
-          backgroundAssetNames={Object.fromEntries(backgroundAssets.map((asset) => [asset.id, asset.displayName]))}
-          onClose={closeReview}
-          onApply={applyReviewedChanges}
-          onRetry={() => void openReview()}
-          onRecover={() => void recoverReview()}
-          onUseSuggestedSource={(candidateId) => void moveDraftToCandidate(candidateId)}
-        />
-      )}
-      {graphOpen && <ConfigGraphPanel graph={configGraph} onClose={() => setGraphOpen(false)} />}
-      {sourcePanelOpen && (
-        <ConfigSourcePanel
-          environment={environment}
-          activeCandidate={activeCandidate}
-          pendingChanges={changes.length}
-          switchingCandidateId={switchingCandidateId}
-          error={sourceError}
-          onClose={() => setSourcePanelOpen(false)}
-          onOpenGraph={() => {
-            setSourcePanelOpen(false);
-            setGraphOpen(true);
-          }}
-          onSelect={switchCandidate}
-          onCreate={createCandidate}
-        />
-      )}
-      {historyOpen && (
-        <SnapshotHistoryPanel
-          snapshots={snapshots}
-          loading={historyLoading}
-          error={historyError}
-          success={historyNotice}
-          readOnly={!isDesktop || (session?.readOnly ?? true)}
-          busy={switchingCandidateId !== null || applying}
-          pendingChanges={changes.length}
-          restoringId={restoringSnapshotId}
-          onClose={() => setHistoryOpen(false)}
-          onRetry={() => void loadSnapshots()}
-          onRestore={restoreSnapshot}
-        />
-      )}
+      <Presence show={reviewOpen || graphOpen || sourcePanelOpen || historyOpen}>
+        {reviewOpen ? (
+          <ReviewPanel
+            changes={changes}
+            preview={changePreview}
+            loading={reviewLoading}
+            applying={applying}
+            busy={switchingCandidateId !== null || restoringSnapshotId !== null}
+            canRecover={reviewCanRecover}
+            readOnly={session?.readOnly ?? true}
+            targetLabel={activeCandidate?.label}
+            previewOnly={!isDesktop}
+            backgroundAssetNames={Object.fromEntries(backgroundAssets.map((asset) => [asset.id, asset.displayName]))}
+            onClose={closeReview}
+            onApply={applyReviewedChanges}
+            onRetry={() => void openReview()}
+            onRecover={() => void recoverReview()}
+            onUseSuggestedSource={(candidateId) => void moveDraftToCandidate(candidateId)}
+          />
+        ) : graphOpen ? (
+          <ConfigGraphPanel graph={configGraph} onClose={() => setGraphOpen(false)} />
+        ) : sourcePanelOpen ? (
+          <ConfigSourcePanel
+            environment={environment}
+            activeCandidate={activeCandidate}
+            pendingChanges={changes.length}
+            switchingCandidateId={switchingCandidateId}
+            error={sourceError}
+            onClose={() => setSourcePanelOpen(false)}
+            onOpenGraph={() => {
+              setSourcePanelOpen(false);
+              setGraphOpen(true);
+            }}
+            onSelect={switchCandidate}
+            onCreate={createCandidate}
+          />
+        ) : historyOpen ? (
+          <SnapshotHistoryPanel
+            snapshots={snapshots}
+            loading={historyLoading}
+            error={historyError}
+            success={historyNotice}
+            readOnly={!isDesktop || (session?.readOnly ?? true)}
+            busy={switchingCandidateId !== null || applying}
+            pendingChanges={changes.length}
+            restoringId={restoringSnapshotId}
+            onClose={() => setHistoryOpen(false)}
+            onRetry={() => void loadSnapshots()}
+            onRestore={restoreSnapshot}
+          />
+        ) : null}
+      </Presence>
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2041,6 +2041,8 @@ export default function App() {
             }}
             placeholder={text("搜索设置", "Search settings")}
             aria-label={text("搜索设置", "Search settings")}
+            aria-keyshortcuts="Meta+K Control+K"
+            aria-describedby={search ? "search-result-count" : undefined}
           />
           {search ? (
             <button
@@ -2191,7 +2193,11 @@ export default function App() {
                 <div className="section-heading">
                   <div>
                     <h1>{pageTitle}</h1>
-                    {pageDescription && <p>{pageDescription}</p>}
+                    {pageDescription && (
+                      <p id="search-result-count" role="status" aria-live="polite" aria-atomic="true">
+                        {pageDescription}
+                      </p>
+                    )}
                   </div>
                 </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -485,6 +485,7 @@ export default function App() {
       if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === "k") {
         event.preventDefault();
         searchInputRef.current?.focus();
+        searchInputRef.current?.select();
       }
       if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === "s") {
         event.preventDefault();
@@ -2032,6 +2033,12 @@ export default function App() {
             ref={searchInputRef}
             value={search}
             onChange={(event) => setSearch(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape" && search) {
+                event.preventDefault();
+                setSearch("");
+              }
+            }}
             placeholder={text("搜索设置", "Search settings")}
             aria-label={text("搜索设置", "Search settings")}
           />

--- a/src/app-concurrency.test.tsx
+++ b/src/app-concurrency.test.tsx
@@ -207,9 +207,13 @@ describe("source migration concurrency", () => {
     backendMock.probeEnvironment.mockReturnValueOnce(new Promise((resolve) => {
       resolveProbe = resolve;
     }));
-    act(() => container.querySelector<HTMLButtonElement>(
+    const reloadButton = container.querySelector<HTMLButtonElement>(
       'button[aria-label="重新读取 Ghostty 配置"]',
-    )!.click());
+    )!;
+    act(() => reloadButton.click());
+
+    expect(reloadButton.getAttribute("aria-busy")).toBe("true");
+    expect(reloadButton.getAttribute("aria-label")).toBe("正在重新读取 Ghostty 配置…");
 
     const opacity = changeOpacity("77");
     startPendingMigration();

--- a/src/app-journey.test.tsx
+++ b/src/app-journey.test.tsx
@@ -234,6 +234,39 @@ describe("primary application journey", () => {
     expect(row.querySelector("input, select, button")).toBeNull();
   });
 
+  it("selects the current search with Command-K and clears it with Escape", async () => {
+    const preferred = environment.candidates[0];
+    window.localStorage.setItem("ghostty-studio:preferred-candidate", preferred.id);
+    act(() => root.render(<App />));
+    await settle();
+
+    const search = container.querySelector<HTMLInputElement>('input[aria-label="搜索设置"]')!;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    act(() => {
+      setter.call(search, "opacity");
+      search.dispatchEvent(new Event("input", { bubbles: true }));
+      search.blur();
+    });
+
+    act(() => window.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "k",
+      metaKey: true,
+      bubbles: true,
+    })));
+
+    expect(document.activeElement).toBe(search);
+    expect(search.selectionStart).toBe(0);
+    expect(search.selectionEnd).toBe("opacity".length);
+
+    act(() => search.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+    })));
+
+    expect(search.value).toBe("");
+    expect(document.activeElement).toBe(search);
+  });
+
   it("moves from the complete catalog to the real editor", async () => {
     const preferred = environment.candidates[0];
     window.localStorage.setItem("ghostty-studio:preferred-candidate", preferred.id);

--- a/src/app-journey.test.tsx
+++ b/src/app-journey.test.tsx
@@ -248,6 +248,12 @@ describe("primary application journey", () => {
       search.blur();
     });
 
+    const resultStatus = container.querySelector<HTMLElement>("#search-result-count")!;
+    expect(search.getAttribute("aria-keyshortcuts")).toBe("Meta+K Control+K");
+    expect(search.getAttribute("aria-describedby")).toBe("search-result-count");
+    expect(resultStatus.getAttribute("role")).toBe("status");
+    expect(resultStatus.getAttribute("aria-live")).toBe("polite");
+
     act(() => window.dispatchEvent(new KeyboardEvent("keydown", {
       key: "k",
       metaKey: true,
@@ -265,6 +271,8 @@ describe("primary application journey", () => {
 
     expect(search.value).toBe("");
     expect(document.activeElement).toBe(search);
+    expect(search.hasAttribute("aria-describedby")).toBe(false);
+    expect(container.querySelector("#search-result-count")).toBeNull();
   });
 
   it("moves from the complete catalog to the real editor", async () => {

--- a/src/app-journey.test.tsx
+++ b/src/app-journey.test.tsx
@@ -124,6 +124,10 @@ describe("primary application journey", () => {
     expect(backend.openConfig).toHaveBeenCalledTimes(1);
     expect(backend.openConfig).toHaveBeenCalledWith(preferred.id);
     expect(container.querySelector(".settings-pane")).not.toBeNull();
+    const connection = container.querySelector<HTMLElement>(".connection-state")!;
+    expect(connection.getAttribute("role")).toBe("status");
+    expect(connection.getAttribute("aria-label")).toBe("试用模式");
+    expect(connection.getAttribute("title")).toBe(connection.getAttribute("aria-label"));
     expect(container.textContent).not.toContain("扩展实验室");
     expect(container.textContent).not.toContain("本地工作台");
   });
@@ -157,6 +161,23 @@ describe("primary application journey", () => {
     expect(container.querySelectorAll('[role="dialog"]')).toHaveLength(1);
     expect(container.querySelector('[role="dialog"] h2')?.textContent).toBe("选择写入位置");
     expect(backend.stageChanges).not.toHaveBeenCalled();
+  });
+
+  it("switches dialog content without stacking two modal layers", async () => {
+    const preferred = environment.candidates[0];
+    window.localStorage.setItem("ghostty-studio:preferred-candidate", preferred.id);
+    act(() => root.render(<App />));
+    await settle();
+
+    act(() => container.querySelector<HTMLButtonElement>(".source-context")!.click());
+    const advanced = container.querySelector<HTMLDetailsElement>(".source-advanced")!;
+    act(() => advanced.setAttribute("open", ""));
+    const loadingDetails = [...advanced.querySelectorAll<HTMLButtonElement>("button")]
+      .find((button) => button.textContent?.trim() === "查看加载详情")!;
+    act(() => loadingDetails.click());
+
+    expect(container.querySelectorAll('[role="dialog"]')).toHaveLength(1);
+    expect(container.querySelector('[role="dialog"] h2')?.textContent).toBe("配置来源");
   });
 
   it("keeps the editing journey free of disabled reference controls", async () => {
@@ -212,7 +233,7 @@ describe("primary application journey", () => {
     expect(themeRow.textContent).toContain("这份文件已设置");
     expect(themeRow.textContent).toContain("原值已保留");
     expect(themeRow.textContent).not.toContain("Catppuccin");
-    expect(themeRow.querySelector("input, select, button")).toBeNull();
+    expect(themeRow.querySelector("input, select, .reference-setting-row__state button")).toBeNull();
   });
 
   it("returns unsupported search matches as reference content", async () => {
@@ -221,7 +242,8 @@ describe("primary application journey", () => {
     act(() => root.render(<App />));
     await settle();
 
-    const search = container.querySelector<HTMLInputElement>('input[aria-label="搜索设置"]')!;
+    const search = container.querySelector<HTMLInputElement>('input[aria-label="搜索名称或 Ghostty 配置项"]')!;
+    expect(search.placeholder).toBe("搜索名称或 Ghostty 配置项");
     const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
     act(() => {
       setter.call(search, "theme");
@@ -231,7 +253,26 @@ describe("primary application journey", () => {
     expect(container.textContent).toContain("全部设置");
     const row = container.querySelector<HTMLElement>(".reference-setting-row")!;
     expect(row.querySelector("code")?.textContent).toBe("theme");
-    expect(row.querySelector("input, select, button")).toBeNull();
+    expect(row.querySelector("input, select, .reference-setting-row__state button")).toBeNull();
+  });
+
+  it("echoes an unmatched query so the empty state is unambiguous", async () => {
+    const preferred = environment.candidates[0];
+    window.localStorage.setItem("ghostty-studio:preferred-candidate", preferred.id);
+    act(() => root.render(<App />));
+    await settle();
+
+    const search = container.querySelector<HTMLInputElement>(
+      'input[aria-label="搜索名称或 Ghostty 配置项"]',
+    )!;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    act(() => {
+      setter.call(search, "no-such-ghostty-key");
+      search.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(container.querySelector(".empty-state")?.textContent)
+      .toContain("没有找到与“no-such-ghostty-key”相关的设置");
   });
 
   it("selects the current search with Command-K and clears it with Escape", async () => {
@@ -240,7 +281,7 @@ describe("primary application journey", () => {
     act(() => root.render(<App />));
     await settle();
 
-    const search = container.querySelector<HTMLInputElement>('input[aria-label="搜索设置"]')!;
+    const search = container.querySelector<HTMLInputElement>('input[aria-label="搜索名称或 Ghostty 配置项"]')!;
     const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
     act(() => {
       setter.call(search, "opacity");
@@ -313,8 +354,8 @@ describe("primary application journey", () => {
       .find((row) => row.querySelector("code")?.textContent === "background")!;
     expect(background).toBeTruthy();
     expect(background.textContent).toContain("多处设置");
-    expect(background.querySelector("input, select, button")).toBeNull();
-    act(() => background.querySelector<HTMLDetailsElement>("details")!.setAttribute("open", ""));
+    expect(background.querySelector("input, select, .reference-setting-row__state button")).toBeNull();
+    act(() => background.querySelector<HTMLButtonElement>(".disclosure-summary")!.click());
     expect(background.textContent).toContain("这份文件中出现了 2 次");
     expect(background.textContent).toContain("请在配置文件中合并或编辑这些值");
   });

--- a/src/components/Disclosure.tsx
+++ b/src/components/Disclosure.tsx
@@ -1,0 +1,46 @@
+import { useId, useState, type ReactNode } from "react";
+
+interface DisclosureProps {
+  className: string;
+  summary: ReactNode;
+  summaryLabel?: string;
+  children: ReactNode;
+  bodyClassName?: string;
+  defaultOpen?: boolean;
+}
+
+export function Disclosure({
+  className,
+  summary,
+  summaryLabel,
+  children,
+  bodyClassName,
+  defaultOpen = false,
+}: DisclosureProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const panelId = useId();
+
+  return (
+    <div className={className} data-expanded={open ? "true" : "false"}>
+      <button
+        type="button"
+        className="disclosure-summary"
+        aria-label={summaryLabel}
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((current) => !current)}
+      >
+        {summary}
+      </button>
+      <div
+        id={panelId}
+        className="disclosure-viewport"
+        aria-hidden={!open}
+      >
+        <div className="disclosure-clip">
+          <div className={bodyClassName}>{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Presence.tsx
+++ b/src/components/Presence.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+export type PresenceState = "entering" | "open" | "exiting";
+
+interface PresenceProps {
+  show: boolean;
+  children: ReactNode;
+  exitDuration?: number;
+  className?: string;
+}
+
+function reducedMotionPreferred(): boolean {
+  return typeof window !== "undefined"
+    && typeof window.matchMedia === "function"
+    && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function Presence({
+  show,
+  children,
+  exitDuration = 180,
+  className = "",
+}: PresenceProps) {
+  const [mounted, setMounted] = useState(show);
+  const [state, setState] = useState<PresenceState>(show ? "open" : "exiting");
+  const lastVisibleChildren = useRef(children);
+
+  if (show) lastVisibleChildren.current = children;
+
+  useEffect(() => {
+    if (show) {
+      if (!mounted) {
+        setMounted(true);
+        setState("entering");
+      } else if (state === "exiting") {
+        setState("open");
+      }
+      return;
+    }
+
+    if (mounted && state !== "exiting") setState("exiting");
+  }, [mounted, show, state]);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    if (show && state === "entering") {
+      const frame = window.requestAnimationFrame(() => setState("open"));
+      return () => window.cancelAnimationFrame(frame);
+    }
+
+    if (!show && state === "exiting") {
+      const timeout = window.setTimeout(
+        () => setMounted(false),
+        reducedMotionPreferred() ? 0 : exitDuration,
+      );
+      return () => window.clearTimeout(timeout);
+    }
+  }, [exitDuration, mounted, show, state]);
+
+  if (!mounted) return null;
+
+  return (
+    <div className={`presence ${className}`.trim()} data-presence={state}>
+      {show ? children : lastVisibleChildren.current}
+    </div>
+  );
+}

--- a/src/components/ReferenceSettingRow.tsx
+++ b/src/components/ReferenceSettingRow.tsx
@@ -4,6 +4,7 @@ import { copyForSetting } from "../settingCopy";
 import type { ConfiguredSetting, RuntimeOption, SettingActivation } from "../types";
 import { isGenericallyEditable } from "../productModel";
 import { localizedSettingChoice } from "../settingChoices";
+import { Disclosure } from "./Disclosure";
 
 interface ReferenceSettingRowProps {
   option: RuntimeOption;
@@ -172,40 +173,40 @@ export function ReferenceSettingRow({
         )}
       </div>
 
-      <details className="reference-setting-row__details">
-        <summary aria-label={text(`查看${copy.label}说明`, `About ${copy.label}`)}>
-          <ChevronRight size={13} /> {text("详情", "Details")}
-        </summary>
-        <div>
-          {detail && (
-            <details className="setting-official-detail">
-              <summary>{text("Ghostty 原文", "Ghostty documentation")}</summary>
-              <p>{detail}</p>
-            </details>
-          )}
-          {!editable && (
-            <p>
-              {duplicated
+      <Disclosure
+        className="reference-setting-row__details"
+        summary={<><ChevronRight size={13} /> {text("详情", "Details")}</>}
+        summaryLabel={text(`查看${copy.label}说明`, `About ${copy.label}`)}
+        bodyClassName="reference-setting-row__body"
+      >
+        {detail && (
+          <details className="setting-official-detail">
+            <summary>{text("Ghostty 原文", "Ghostty documentation")}</summary>
+            <p>{detail}</p>
+          </details>
+        )}
+        {!editable && (
+          <p>
+            {duplicated
+              ? text(
+                  "请在配置文件中合并或编辑这些值。",
+                  "Merge or edit these values in the configuration file.",
+                )
+              : blockedByWorkspace
                 ? text(
-                    "请在配置文件中合并或编辑这些值。",
-                    "Merge or edit these values in the configuration file.",
+                    "选择可写配置后即可调整。",
+                    "Choose a writable configuration to edit this setting.",
                   )
-                : blockedByWorkspace
-                  ? text(
-                      "选择可写配置后即可调整。",
-                      "Choose a writable configuration to edit this setting.",
-                    )
-                  : restrictionDescription(locale, option)}
-            </p>
-          )}
-          {activation && (
-            <p>{text(`更改会在${activation}生效。`, `Changes take effect ${activation}.`)}</p>
-          )}
-          {option.platform && option.capability.reason !== "platform-unavailable" && (
-            <p>{text(`适用于 ${option.platform}。`, `Available on ${option.platform}.`)}</p>
-          )}
-        </div>
-      </details>
+                : restrictionDescription(locale, option)}
+          </p>
+        )}
+        {activation && (
+          <p>{text(`更改会在${activation}生效。`, `Changes take effect ${activation}.`)}</p>
+        )}
+        {option.platform && option.capability.reason !== "platform-unavailable" && (
+          <p>{text(`适用于 ${option.platform}。`, `Available on ${option.platform}.`)}</p>
+        )}
+      </Disclosure>
     </article>
   );
 }

--- a/src/components/SettingRow.tsx
+++ b/src/components/SettingRow.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "../i18n";
 import { copyForSetting } from "../settingCopy";
 import type { RuntimeOption } from "../types";
 import { localizedSettingChoice } from "../settingChoices";
+import { Disclosure } from "./Disclosure";
 import { SettingControl } from "./SettingControl";
 
 interface SettingRowProps {
@@ -67,40 +68,40 @@ export const SettingRow = memo(function SettingRow({
           <RotateCcw size={14} />
         </button>
       </div>
-      <details className="setting-inspector">
-        <summary aria-label={text(`查看${copy.label}说明`, `About ${copy.label}`)}>
-          <ChevronRight size={13} /> {text("详情", "Details")}
-        </summary>
-        <div className="setting-inspector__body">
-          <dl>
-            <div><dt>{text("配置名", "Configuration key")}</dt><dd><code>{option.key}</code></dd></div>
-            <div><dt>{text("默认值", "Default")}</dt><dd>{defaultValue}</dd></div>
-            <div>
-              <dt>{text("这份文件", "This file")}</dt>
-              <dd>{configuredInEditingLayer ? sourceLabel : text("未设置", "Not set")}</dd>
-            </div>
-          </dl>
-          {copy.detail && (
-            <details className="setting-official-detail">
-              <summary>{text("Ghostty 原文", "Ghostty documentation")}</summary>
-              <p>{copy.detail}</p>
-            </details>
-          )}
-          {configuredInEditingLayer && (
-            <button
-              type="button"
-              className="setting-unset"
-              disabled={value === ""}
-              onClick={() => onValueChange(option.key, "")}
-            >
-              <CircleMinus size={13} />
-              {value === ""
-                ? text("保存时移除", "Will be removed when saved")
-                : text("从这份文件移除", "Remove from this file")}
-            </button>
-          )}
-        </div>
-      </details>
+      <Disclosure
+        className="setting-inspector"
+        summary={<><ChevronRight size={13} /> {text("详情", "Details")}</>}
+        summaryLabel={text(`查看${copy.label}说明`, `About ${copy.label}`)}
+        bodyClassName="setting-inspector__body"
+      >
+        <dl>
+          <div><dt>{text("配置名", "Configuration key")}</dt><dd><code>{option.key}</code></dd></div>
+          <div><dt>{text("默认值", "Default")}</dt><dd>{defaultValue}</dd></div>
+          <div>
+            <dt>{text("这份文件", "This file")}</dt>
+            <dd>{configuredInEditingLayer ? sourceLabel : text("未设置", "Not set")}</dd>
+          </div>
+        </dl>
+        {copy.detail && (
+          <details className="setting-official-detail">
+            <summary>{text("Ghostty 原文", "Ghostty documentation")}</summary>
+            <p>{copy.detail}</p>
+          </details>
+        )}
+        {configuredInEditingLayer && (
+          <button
+            type="button"
+            className="setting-unset"
+            disabled={value === ""}
+            onClick={() => onValueChange(option.key, "")}
+          >
+            <CircleMinus size={13} />
+            {value === ""
+              ? text("保存时移除", "Will be removed when saved")
+              : text("从这份文件移除", "Remove from this file")}
+          </button>
+        )}
+      </Disclosure>
     </article>
   );
 });

--- a/src/interaction-motion.test.tsx
+++ b/src/interaction-motion.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Disclosure } from "./components/Disclosure";
+import { Presence } from "./components/Presence";
+
+function PresenceHarness() {
+  const [show, setShow] = useState(false);
+  return (
+    <div>
+      <button type="button" onClick={() => setShow(true)}>open</button>
+      <button type="button" onClick={() => setShow(false)}>close</button>
+      <Presence show={show}><div data-testid="panel">panel</div></Presence>
+    </div>
+  );
+}
+
+describe("interaction motion", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+      .IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => (
+      window.setTimeout(() => callback(performance.now()), 16)
+    ));
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation((handle) => {
+      window.clearTimeout(handle);
+    });
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("keeps exits mounted and reverses them when reopened", () => {
+    act(() => root.render(<PresenceHarness />));
+    const [open, close] = container.querySelectorAll<HTMLButtonElement>("button");
+
+    act(() => open.click());
+    expect(container.querySelector(".presence")?.getAttribute("data-presence")).toBe("entering");
+    act(() => vi.advanceTimersByTime(16));
+    expect(container.querySelector(".presence")?.getAttribute("data-presence")).toBe("open");
+
+    act(() => close.click());
+    expect(container.querySelector('[data-testid="panel"]')).not.toBeNull();
+    expect(container.querySelector(".presence")?.getAttribute("data-presence")).toBe("exiting");
+
+    act(() => open.click());
+    act(() => vi.advanceTimersByTime(200));
+    expect(container.querySelector(".presence")?.getAttribute("data-presence")).toBe("open");
+
+    act(() => close.click());
+    act(() => vi.advanceTimersByTime(180));
+    expect(container.querySelector('[data-testid="panel"]')).toBeNull();
+  });
+
+  it("does not delay removal when reduced motion is preferred", () => {
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: true }));
+    act(() => root.render(<PresenceHarness />));
+    const [open, close] = container.querySelectorAll<HTMLButtonElement>("button");
+
+    act(() => open.click());
+    act(() => vi.advanceTimersByTime(16));
+    act(() => close.click());
+    act(() => vi.runOnlyPendingTimers());
+
+    expect(container.querySelector('[data-testid="panel"]')).toBeNull();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps disclosure state accessible during rapid reversals", () => {
+    act(() => root.render(
+      <Disclosure
+        className="test-disclosure"
+        summary="Details"
+        summaryLabel="About this setting"
+      >
+        <button type="button">Nested action</button>
+      </Disclosure>,
+    ));
+
+    const summary = container.querySelector<HTMLButtonElement>(".disclosure-summary")!;
+    const viewport = container.querySelector<HTMLElement>(".disclosure-viewport")!;
+    expect(summary.getAttribute("aria-expanded")).toBe("false");
+    expect(viewport.getAttribute("aria-hidden")).toBe("true");
+
+    act(() => summary.click());
+    expect(summary.getAttribute("aria-expanded")).toBe("true");
+    expect(viewport.getAttribute("aria-hidden")).toBe("false");
+
+    act(() => summary.click());
+    expect(summary.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector(".test-disclosure")?.getAttribute("data-expanded")).toBe("false");
+  });
+});

--- a/src/layout-css.test.ts
+++ b/src/layout-css.test.ts
@@ -5,17 +5,20 @@ import { describe, expect, it } from "vitest";
 const css = readFileSync(new URL("./styles.css", import.meta.url), "utf8");
 
 // Resolve every desktop/base layer while excluding responsive and preference
-// media states. This catches cascade regressions where an older component rule
+// states. This catches cascade regressions where an older component rule
 // accidentally overrides the current design-system layer.
-function withoutMediaBlocks(source: string): string {
+function withoutConditionalBlocks(source: string): string {
   let cursor = 0;
   let result = "";
   while (cursor < source.length) {
     const mediaStart = source.indexOf("@media", cursor);
-    if (mediaStart < 0) return result + source.slice(cursor);
-    result += source.slice(cursor, mediaStart);
-    const blockStart = source.indexOf("{", mediaStart);
-    expect(blockStart, "unterminated media query").toBeGreaterThan(mediaStart);
+    const containerStart = source.indexOf("@container", cursor);
+    const starts = [mediaStart, containerStart].filter((index) => index >= 0);
+    if (starts.length === 0) return result + source.slice(cursor);
+    const conditionalStart = Math.min(...starts);
+    result += source.slice(cursor, conditionalStart);
+    const blockStart = source.indexOf("{", conditionalStart);
+    expect(blockStart, "unterminated conditional rule").toBeGreaterThan(conditionalStart);
     let depth = 1;
     let index = blockStart + 1;
     while (index < source.length && depth > 0) {
@@ -23,13 +26,13 @@ function withoutMediaBlocks(source: string): string {
       if (source[index] === "}") depth -= 1;
       index += 1;
     }
-    expect(depth, "unterminated media-query block").toBe(0);
+    expect(depth, "unterminated conditional block").toBe(0);
     cursor = index;
   }
   return result;
 }
 
-const desktopCss = withoutMediaBlocks(css);
+const desktopCss = withoutConditionalBlocks(css);
 
 function ruleBlocks(header: string): string[] {
   const escapedHeader = header.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -151,6 +154,24 @@ describe("layout contract", () => {
     expectDeclaration(".setting-input", "display", "grid");
     expectDeclaration(".setting-input", "grid-template-columns", "minmax(0, 1fr) 32px");
     expectDeclaration(".setting-inspector", "grid-column", "1 / -1");
+  });
+
+  it("adapts setting rows to their content pane instead of the outer window", () => {
+    expectDeclaration(".settings-pane", "container-name", "settings-pane");
+    expectDeclaration(".settings-pane", "container-type", "inline-size");
+    const query = css.slice(css.indexOf("@container settings-pane (max-width: 640px)"));
+    expect(query).toContain(".setting-row,");
+    expect(query).toContain("grid-template-columns: minmax(0, 1fr)");
+    expect(query).toContain("grid-template-columns: minmax(0, 240px) 32px");
+  });
+
+  it("uses shared motion timing and keeps reduced-motion support", () => {
+    expectDeclaration(":root", "--motion-standard", "180ms");
+    expectDeclaration(":root", "--motion-dialog", "200ms");
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(css).toContain('.presence[data-presence="exiting"] .review-backdrop');
+    expect(css.match(/^\.review-backdrop \{/gm)).toHaveLength(1);
+    expect(css.match(/^\.review-panel \{/gm)).toHaveLength(1);
   });
 
   it("removes empty feedback spacing and keeps the switch state visible", () => {

--- a/src/reference-setting-row.test.tsx
+++ b/src/reference-setting-row.test.tsx
@@ -36,7 +36,7 @@ describe("reference setting states", () => {
     expect(container.textContent).toContain("多处设置");
     expect(container.textContent).toContain("这份文件中出现了 2 次");
     expect(container.textContent).toContain("请在配置文件中合并或编辑这些值");
-    expect(container.querySelector("button")).toBeNull();
+    expect(container.querySelector(".reference-setting-row__state button")).toBeNull();
   });
 
   it("does not offer an adjustment action for a read-only workspace", () => {
@@ -51,6 +51,6 @@ describe("reference setting states", () => {
 
     expect(container.textContent).toContain("配置只读");
     expect(container.textContent).toContain("选择可写配置后即可调整");
-    expect(container.querySelector("button")).toBeNull();
+    expect(container.querySelector(".reference-setting-row__state button")).toBeNull();
   });
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -378,7 +378,7 @@ kbd {
   min-height: 104px;
   padding: 18px 20px;
   border-bottom: 1px solid var(--border-soft);
-  transition: background 140ms ease;
+  transition: background var(--motion-fast) ease;
 }
 
 .setting-copy,
@@ -1021,29 +1021,6 @@ select:focus,
 .boot-screen span {
   color: var(--text-muted);
   font-size: 11px;
-}
-
-.review-backdrop {
-  position: fixed;
-  z-index: 100;
-  inset: 0;
-  display: flex;
-  justify-content: flex-end;
-  background: rgba(0, 0, 0, 0.58);
-  backdrop-filter: blur(4px);
-}
-
-.review-panel {
-  display: grid;
-  width: min(100%, 560px);
-  height: 100%;
-  min-width: 0;
-  min-height: 0;
-  grid-template-rows: auto minmax(0, 1fr) auto;
-  overflow: hidden;
-  border-left: 1px solid var(--border);
-  background: #101216;
-  box-shadow: -24px 0 60px rgba(0, 0, 0, 0.32);
 }
 
 .review-header {
@@ -3368,6 +3345,8 @@ textarea:focus-visible {
 }
 
 .settings-pane {
+  container-name: settings-pane;
+  container-type: inline-size;
   padding: 30px 32px 132px;
 }
 
@@ -3552,7 +3531,7 @@ textarea:focus-visible {
   font-size: 11px;
 }
 
-.setting-inspector > summary {
+.setting-inspector > .disclosure-summary {
   display: inline-flex;
   min-height: 24px;
   align-items: center;
@@ -3562,11 +3541,7 @@ textarea:focus-visible {
   list-style: none;
 }
 
-.setting-inspector > summary::-webkit-details-marker {
-  display: none;
-}
-
-.setting-inspector > summary:hover {
+.setting-inspector > .disclosure-summary:hover {
   color: var(--text-secondary);
 }
 
@@ -3716,13 +3691,13 @@ textarea:focus-visible {
   font-size: 11px;
 }
 
-.reference-setting-row__details > summary {
+.reference-setting-row__details > .disclosure-summary {
   width: fit-content;
   min-height: 24px;
   cursor: pointer;
 }
 
-.reference-setting-row__details > div {
+.reference-setting-row__body {
   margin-top: 6px;
   padding: 9px 10px;
   border-radius: 7px;
@@ -3894,8 +3869,11 @@ select,
   margin-bottom: 20px;
 }
 
-.inline-preview > summary {
+.inline-preview > .disclosure-summary {
+  display: inline-flex;
   min-height: 32px;
+  align-items: center;
+  gap: var(--space-1);
   padding: 7px 9px;
   border: 1px solid var(--border-soft);
   border-radius: 7px;
@@ -4027,7 +4005,7 @@ select,
   font-size: 12px;
 }
 
-.draft-dock + .save-toast {
+.draft-presence + .toast-presence .save-toast {
   bottom: 86px;
 }
 
@@ -4144,22 +4122,36 @@ select,
 }
 
 .review-backdrop {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: flex;
   align-items: center;
   justify-content: center;
   padding: 24px;
   background: rgba(0, 0, 0, 0.46);
   backdrop-filter: blur(5px);
+  opacity: 1;
+  transition: opacity var(--motion-dialog) var(--motion-ease-standard);
 }
 
 .review-panel {
+  display: grid;
   width: min(660px, 100%);
   max-width: 660px;
   height: auto;
+  min-width: 0;
+  min-height: 0;
   max-height: min(760px, calc(100vh - 48px));
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 14px;
   background: var(--panel-raised);
   box-shadow: 0 28px 80px rgba(0, 0, 0, 0.42);
+  transform: translateY(0) scale(1);
+  transform-origin: center;
+  transition: transform var(--motion-dialog) var(--motion-ease-out);
 }
 
 .review-header {
@@ -4582,10 +4574,84 @@ select,
   --preview-column-width: clamp(320px, 28vw, 352px);
   --copy-measure: 52ch;
   --focus-ring: #a8ff60;
+  --motion-fast: 120ms;
+  --motion-standard: 180ms;
+  --motion-dialog: 200ms;
+  --motion-ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --motion-ease-standard: cubic-bezier(0.2, 0, 0, 1);
 }
 
 body {
   font-size: var(--font-body);
+}
+
+.presence {
+  display: contents;
+}
+
+.presence[data-presence="entering"] .review-backdrop,
+.presence[data-presence="exiting"] .review-backdrop {
+  opacity: 0;
+}
+
+.presence[data-presence="entering"] .review-panel,
+.presence[data-presence="exiting"] .review-panel {
+  transform: translateY(10px) scale(0.985);
+}
+
+.presence[data-presence="exiting"] .review-backdrop {
+  pointer-events: none;
+}
+
+.draft-dock,
+.save-toast {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  transition:
+    opacity var(--motion-standard) var(--motion-ease-standard),
+    transform var(--motion-standard) var(--motion-ease-out);
+}
+
+.presence[data-presence="entering"] .draft-dock,
+.presence[data-presence="exiting"] .draft-dock,
+.presence[data-presence="entering"] .save-toast,
+.presence[data-presence="exiting"] .save-toast {
+  opacity: 0;
+  transform: translateY(8px) scale(0.99);
+  pointer-events: none;
+}
+
+.disclosure-summary {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+}
+
+.disclosure-viewport {
+  display: grid;
+  grid-template-rows: 0fr;
+  visibility: hidden;
+  opacity: 0;
+  transition:
+    grid-template-rows var(--motion-standard) var(--motion-ease-standard),
+    opacity var(--motion-fast) var(--motion-ease-standard),
+    visibility 0s linear var(--motion-standard);
+}
+
+[data-expanded="true"] > .disclosure-viewport {
+  grid-template-rows: 1fr;
+  visibility: visible;
+  opacity: 1;
+  transition-delay: 0s;
+}
+
+.disclosure-clip {
+  min-height: 0;
+  overflow: hidden;
 }
 
 .section-heading p,
@@ -4685,8 +4751,8 @@ body {
   margin-top: 0;
 }
 
-.setting-inspector > summary,
-.reference-setting-row__details > summary {
+.setting-inspector > .disclosure-summary,
+.reference-setting-row__details > .disclosure-summary {
   display: inline-flex;
   min-height: var(--control-compact-height);
   align-items: center;
@@ -4698,19 +4764,21 @@ body {
   list-style: none;
 }
 
-.setting-inspector > summary svg,
-.reference-setting-row__details > summary svg {
+.setting-inspector > .disclosure-summary svg,
+.reference-setting-row__details > .disclosure-summary svg,
+.inline-preview > .disclosure-summary svg {
   flex: 0 0 auto;
-  transition: transform 140ms ease;
+  transition: transform var(--motion-standard) var(--motion-ease-standard);
 }
 
-.setting-inspector[open] > summary svg,
-.reference-setting-row__details[open] > summary svg {
+.setting-inspector[data-expanded="true"] > .disclosure-summary svg,
+.reference-setting-row__details[data-expanded="true"] > .disclosure-summary svg,
+.inline-preview[data-expanded="true"] > .disclosure-summary svg {
   transform: rotate(90deg);
 }
 
 .setting-inspector__body,
-.reference-setting-row__details > div {
+.reference-setting-row__body {
   margin-top: var(--space-1);
   border: 1px solid var(--border-soft);
   background: var(--panel-soft);
@@ -4764,7 +4832,7 @@ select,
 .reference-setting-row__state > button,
 .reference-invitation button,
 .workspace-feedback button,
-.inline-preview > summary,
+.inline-preview > .disclosure-summary,
 .utility-menu__popover button {
   min-height: var(--control-min-height);
 }
@@ -4784,7 +4852,10 @@ select,
   color: var(--text);
   font-size: 12px;
   font-variant-numeric: tabular-nums;
-  transition: border-color 120ms ease, background-color 120ms ease, box-shadow 120ms ease;
+  transition:
+    border-color var(--motion-fast) ease,
+    background-color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease;
 }
 
 select:hover:not(:disabled),
@@ -4914,7 +4985,7 @@ select:focus,
   border-radius: 50%;
   background: #f7f7f8;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.34);
-  transition: box-shadow 120ms ease, transform 120ms ease;
+  transition: box-shadow var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 
 .number-control input[type="range"]:hover:not(:disabled)::-webkit-slider-thumb {
@@ -4998,7 +5069,7 @@ select:focus,
   border: 1px solid var(--control-border-hover);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.13);
-  transition: border-color 140ms ease, background-color 140ms ease;
+  transition: border-color var(--motion-fast) ease, background-color var(--motion-fast) ease;
 }
 
 .switch span {
@@ -5008,7 +5079,7 @@ select:focus,
   height: 16px;
   background: #f4f4f5;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.34);
-  transition: left 140ms ease, transform 120ms ease;
+  transition: left var(--motion-fast) ease, transform var(--motion-fast) ease;
 }
 
 .switch[aria-checked="true"]::before {
@@ -5037,7 +5108,10 @@ select:focus,
   height: var(--control-min-height);
   border-color: transparent;
   border-radius: var(--control-radius);
-  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease;
+  transition:
+    border-color var(--motion-fast) ease,
+    background-color var(--motion-fast) ease,
+    color var(--motion-fast) ease;
 }
 
 .inline-reset:not(:disabled):hover,
@@ -5052,7 +5126,11 @@ select:focus,
 .icon-button,
 .toolbar-icon,
 .reference-setting-row__state > button {
-  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease, transform 80ms ease;
+  transition:
+    border-color var(--motion-fast) ease,
+    background-color var(--motion-fast) ease,
+    color var(--motion-fast) ease,
+    transform 80ms ease;
 }
 
 .button:not(:disabled):active,
@@ -5084,7 +5162,10 @@ select:focus,
   background: var(--control-bg);
   box-shadow: var(--control-shadow);
   color: var(--text-muted);
-  transition: border-color 120ms ease, background-color 120ms ease, box-shadow 120ms ease;
+  transition:
+    border-color var(--motion-fast) ease,
+    background-color var(--motion-fast) ease,
+    box-shadow var(--motion-fast) ease;
 }
 
 .language-picker:hover {
@@ -5139,10 +5220,6 @@ select:focus,
   min-height: 180px;
   border: 1px solid var(--border-soft);
   background: var(--panel);
-}
-
-.review-panel {
-  background: var(--panel-raised);
 }
 
 .review-panel:focus {
@@ -5312,6 +5389,33 @@ select:focus,
   box-shadow: none;
 }
 
+@container settings-pane (max-width: 640px) {
+  .setting-row,
+  .reference-setting-row {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+    gap: var(--space-3);
+  }
+
+  .setting-input,
+  .reference-setting-row__state {
+    justify-content: flex-start;
+    text-align: start;
+  }
+
+  .setting-input {
+    grid-template-columns: minmax(0, 240px) 32px;
+    justify-content: start;
+  }
+
+  .setting-input > select,
+  .setting-input > .text-control,
+  .setting-input > .color-control,
+  .setting-input > .number-control {
+    flex: 1 1 auto;
+  }
+}
+
 @media (min-width: 1151px) {
   .draft-dock--settings-column {
     right: calc(var(--preview-column-width) + var(--space-6));
@@ -5402,31 +5506,6 @@ select:focus,
   .language-picker select {
     min-width: 108px;
     max-width: 150px;
-  }
-
-  .setting-row,
-  .reference-setting-row {
-    grid-template-columns: minmax(0, 1fr);
-    align-items: start;
-    gap: var(--space-3);
-  }
-
-  .setting-input,
-  .reference-setting-row__state {
-    justify-content: flex-start;
-    text-align: start;
-  }
-
-  .setting-input {
-    grid-template-columns: minmax(0, 240px) 32px;
-    justify-content: start;
-  }
-
-  .setting-input > select,
-  .setting-input > .text-control,
-  .setting-input > .color-control,
-  .setting-input > .number-control {
-    flex: 1 1 auto;
   }
 
   .review-backdrop {


### PR DESCRIPTION
## What changed

- Improve repeated search with `⌘K` / `Ctrl+K`, Escape-to-clear, precise bilingual scope copy, and accessible result feedback.
- Add interruptible, reduced-motion-aware transitions for dialogs, setting details, the unsaved-changes dock, and save messages.
- Keep dialogs on a single presentation layer so source, history, graph, and review panels never stack focus traps.
- Expose clear busy and connection status while configuration is being reloaded.
- Adapt setting rows to the available editor width with container queries, including the minimum supported window size.
- Consolidate the modal styling layer and add motion, accessibility, responsive-layout, and dialog-switching regressions.

## Why

These changes make frequent actions immediate, keep lower-frequency state changes spatially understandable, and preserve a clear editing journey from wide layouts down to the minimum window size.

## User impact

Keyboard search is faster, progress and empty states are more precise, narrow windows remain usable, and dialogs or disclosures can be reversed without visual jumps. Reduced-motion preferences remain respected.

## Checks

- `pnpm check`
- 104 frontend tests passed
- 94 Rust tests passed
- Visual checks at 1180×780, 1024×760, and 780×560
- No horizontal overflow or browser console errors

No version bump or release build is included.