### PR TITLE
Document immutable releases and Linux dependency gate

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -14,6 +14,12 @@ active configuration graph, the setting stays visible but read-only.
 | Any other version, channel, platform, or schema hash | Read-only | The runtime catalog may remain searchable, but every write surface is disabled from schema load. There is no per-setting fallback authorization. |
 | Browser demo | Read-only | It uses sample data and never reads or writes a local Ghostty configuration. |
 
+The lockfile currently retains `glib` 0.18.5 through Tauri's Linux GTK dependency graph. That version
+is covered by [GHSA-wrw7-89jp-8q8g](https://github.com/advisories/GHSA-wrw7-89jp-8q8g). It is not
+compiled into the supported Apple Silicon macOS target, and the alert remains open rather than being
+dismissed. A Linux build must not be released until the upstream dependency graph reaches a patched
+`glib` version and Linux CI verifies the resulting package.
+
 The audited contract is `ghostty-1.3.1-stable-macos-v1`. Its schema hash is
 `5e36480fe2ec3d510ffc32de84c617fbaca10e1330c097185301b51ab9c10e6c`, calculated from the complete
 raw `ghostty +show-config --default --docs` output. It exposes 30 ordinary scalar controls plus the
@@ -73,6 +79,9 @@ Preview releases publish a checksum, but the current app does not yet establish 
 publisher identity and is not notarized. Download only from the project's
 [GitHub Releases](https://github.com/SteinsHead/ghostty-studio/releases), verify the checksum, and do
 not use repackaged downloads.
+
+Future published releases are immutable: their assets and associated tags cannot be replaced after
+publication. A release must therefore be assembled and reviewed as a draft before it is published.
 
 CI runs frontend and Rust checks on Ubuntu, dependency review on pull requests, and an ARM64 app build
 smoke test on `macos-15`. Workflow actions are pinned to immutable commits. Both the smoke build and

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -36,8 +36,10 @@ artifact for 14 days; it cannot upload release assets.
 3. Download the artifact and verify `SHA256SUMS.txt` with `shasum -a 256 -c SHA256SUMS.txt`.
 4. Compare `BUILD-MANIFEST.txt` with the requested ref, inspect the app on an Apple Silicon Mac, and
    repeat the privacy checklist in [Launch kit](LAUNCH_KIT.md).
-5. Publish separately only after the artifact, release notes, compatibility statement, and known
-   limits have been reviewed.
+5. Create a draft GitHub Release, attach the reviewed DMG, checksum, build manifest, release notes,
+   compatibility statement, and known limits, then verify the complete draft.
+6. Publish the draft only when every asset is final. The repository enforces immutable releases, so
+   the published assets and associated tag cannot be replaced.
 
 A future public-release workflow needs a protected environment, Developer ID credentials,
 notarization, stapling, publisher verification, and an explicit approval step. Those capabilities must


### PR DESCRIPTION
## Summary

- document the draft-first workflow required by immutable GitHub Releases
- keep the open `glib` advisory visible and record that it is absent from the supported Apple Silicon target
- block any future Linux release until the upstream GTK/Tauri dependency graph reaches a patched `glib` and Linux CI verifies it

## Verification

- `git diff --check`
- `node scripts/build-site.mjs`
- `cargo tree --manifest-path src-tauri/Cargo.toml --locked --target aarch64-apple-darwin -i glib` returns no dependency

No Release or installer was created.