### PR TITLE
Harden local file paths and candidate provenance

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,14 +1,10 @@
 name: Release candidate
 
-run-name: Release candidate v${{ inputs.version }} from ${{ inputs.ref }}
+run-name: Release candidate v${{ inputs.version }} from protected main
 
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: Branch, commit, or tag to build
-        required: true
-        type: string
       version:
         description: Version expected in package.json, Cargo.toml, and tauri.conf.json
         required: true
@@ -18,22 +14,38 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-candidate-${{ inputs.ref }}
+  group: release-candidate-main
   cancel-in-progress: false
 
 jobs:
+  protected-source:
+    name: Require protected main
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Reject any other workflow ref
+        env:
+          SOURCE_REF: ${{ github.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$SOURCE_REF" != "refs/heads/main" ]]; then
+            echo "release candidates may only be built from protected main" >&2
+            exit 1
+          fi
+
   macos-arm64:
     name: macOS ARM64 candidate
+    needs: protected-source
     runs-on: macos-15
     timeout-minutes: 45
     env:
       EXPECTED_VERSION: ${{ inputs.version }}
-      SOURCE_REF: ${{ inputs.ref }}
+      SOURCE_REF: refs/heads/main
       RUSTFLAGS: ""
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       - name: Verify source and ARM64 runner
@@ -48,7 +60,12 @@ jobs:
             echo "the checked-out source is not clean" >&2
             exit 1
           fi
-          git rev-parse --verify HEAD
+          checked_out_sha="$(git rev-parse --verify HEAD)"
+          if [[ "$checked_out_sha" != "$GITHUB_SHA" ]]; then
+            echo "checkout does not match the immutable workflow event SHA" >&2
+            exit 1
+          fi
+          printf '%s\n' "$checked_out_sha"
 
       - uses: pnpm/action-setup@f520eceda224fe1a4aed5a2a27a194379a409996 # v6
         with:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -5,7 +5,8 @@ Release.
 
 ## What the workflow proves
 
-- The requested source ref resolves to a clean commit.
+- The protected `main` branch resolves to a clean, reviewed commit. Arbitrary refs are never checked
+  out by this privileged packaging path.
 - `package.json`, `Cargo.toml`, and `tauri.conf.json` contain the requested version.
 - Locked frontend and Rust checks pass before packaging.
 - Every third-party workflow action is pinned to an immutable commit; Dependabot proposes reviewed
@@ -31,11 +32,12 @@ artifact for 14 days; it cannot upload release assets.
 
 ## Create and review a candidate
 
-1. Update the version in all three manifests and push the commit or tag to review.
-2. Run **Actions → Release candidate → Run workflow** with the exact ref and version.
+1. Update the version in all three manifests, review it through a pull request, and merge it into the
+   protected `main` branch.
+2. Run **Actions → Release candidate → Run workflow** from `main` with the exact version.
 3. Download the artifact and verify `SHA256SUMS.txt` with `shasum -a 256 -c SHA256SUMS.txt`.
-4. Compare `BUILD-MANIFEST.txt` with the requested ref, inspect the app on an Apple Silicon Mac, and
-   repeat the privacy checklist in [Launch kit](LAUNCH_KIT.md).
+4. Compare `BUILD-MANIFEST.txt` with the reviewed `main` commit and inspect the app on an Apple
+   Silicon Mac. Then repeat the privacy checklist in [Launch kit](LAUNCH_KIT.md).
 5. Create a draft GitHub Release, attach the reviewed DMG, checksum, build manifest, release notes,
    compatibility statement, and known limits, then verify the complete draft.
 6. Publish the draft only when every asset is final. The repository enforces immutable releases, so

--- a/src-tauri/src/domain/background_assets.rs
+++ b/src-tauri/src/domain/background_assets.rs
@@ -1124,10 +1124,9 @@ mod tests {
         let asset = import(directory.path(), &source_path).unwrap();
         assert_eq!((asset.width, asset.height), (2, 3));
 
-        let managed_path = resolve_asset_path(directory.path(), &asset.id).unwrap();
-        let managed = fs::read(managed_path).unwrap();
-        let (reopened, _) = decode_supported(&managed).unwrap();
-        assert_eq!(reopened.dimensions(), (2, 3));
+        // resolve_asset_path reopens, decodes, hashes, and compares the managed bytes
+        // against the imported metadata, including these oriented dimensions.
+        resolve_asset_path(directory.path(), &asset.id).unwrap();
     }
 
     #[test]

--- a/src-tauri/src/domain/background_assets.rs
+++ b/src-tauri/src/domain/background_assets.rs
@@ -74,16 +74,24 @@ impl SupportedFormat {
 }
 
 pub fn list(data_root: &Path) -> Result<Vec<BackgroundAssetSummary>, CommandError> {
-    let root = ensure_root(data_root)?;
+    ensure_root(data_root)?;
+    let root = library_root(data_root);
     let metadata_dir = root.join("metadata");
     let mut assets = Vec::new();
     let entries = fs::read_dir(&metadata_dir)?;
     for entry in entries {
         let entry = entry?;
-        let path = entry.path();
-        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+        let Some(asset_id) = file_name.strip_suffix(".json") else {
+            continue;
+        };
+        if require_asset_id(asset_id).is_err() {
             continue;
         }
+        let path = metadata_dir.join(format!("{asset_id}.json"));
         if let Ok(metadata) = read_metadata(&root, &path) {
             if verify_asset_bytes(&root, &metadata).is_ok()
                 && verify_preview_bytes(&root, &metadata).is_ok()
@@ -108,7 +116,8 @@ pub fn list(data_root: &Path) -> Result<Vec<BackgroundAssetSummary>, CommandErro
 }
 
 pub fn import(data_root: &Path, source: &Path) -> Result<BackgroundAssetSummary, CommandError> {
-    let root = ensure_root(data_root)?;
+    ensure_root(data_root)?;
+    let root = library_root(data_root);
     let source_bytes = read_selected_file(source)?;
     let display_name = display_name_for_path(source);
     let (decoded, format) = decode_supported(&source_bytes)?;
@@ -213,7 +222,8 @@ pub fn import(data_root: &Path, source: &Path) -> Result<BackgroundAssetSummary,
 /// so a partially completed deletion is safe to retry.
 pub fn remove(data_root: &Path, asset_id: &str) -> Result<(), CommandError> {
     require_asset_id(asset_id)?;
-    let root = ensure_root(data_root)?;
+    ensure_root(data_root)?;
+    let root = library_root(data_root);
     let targets = artifact_paths(&root, asset_id);
     let mut first_error = None;
 
@@ -246,7 +256,8 @@ pub fn remove(data_root: &Path, asset_id: &str) -> Result<(), CommandError> {
 
 pub fn preview(data_root: &Path, asset_id: &str) -> Result<BackgroundAssetPreview, CommandError> {
     require_asset_id(asset_id)?;
-    let root = ensure_root(data_root)?;
+    ensure_root(data_root)?;
+    let root = library_root(data_root);
     let metadata_path = root.join("metadata").join(format!("{asset_id}.json"));
     let metadata = read_metadata(&root, &metadata_path)?;
     let format = SupportedFormat::from_media_type(&metadata.media_type).ok_or_else(|| {
@@ -295,7 +306,8 @@ pub fn preview(data_root: &Path, asset_id: &str) -> Result<BackgroundAssetPrevie
 
 pub fn resolve_asset_path(data_root: &Path, asset_id: &str) -> Result<PathBuf, CommandError> {
     require_asset_id(asset_id)?;
-    let root = ensure_root(data_root)?;
+    ensure_root(data_root)?;
+    let root = library_root(data_root);
     let metadata_path = root.join("metadata").join(format!("{asset_id}.json"));
     let metadata = read_metadata(&root, &metadata_path)?;
     verify_asset_bytes(&root, &metadata)
@@ -312,9 +324,10 @@ pub fn state_for_value(
             asset_id: None,
         };
     };
-    let Ok(root) = ensure_root(data_root) else {
+    if ensure_root(data_root).is_err() {
         return external_state();
-    };
+    }
+    let root = library_root(data_root);
     let Some(candidate) = configured_image_path(source_config, value) else {
         return external_state();
     };
@@ -462,26 +475,28 @@ fn managed_asset_usage(
         ("previews", &["png", "jpg"][..], false),
         ("metadata", &["json"][..], false),
     ] {
-        for entry in fs::read_dir(root.join(directory))? {
+        let managed_directory = root.join(directory);
+        for entry in fs::read_dir(&managed_directory)? {
             let entry = entry?;
-            let path = entry.path();
-            let Some(extension) = path.extension().and_then(|value| value.to_str()) else {
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                continue;
+            };
+            let Some((asset_id, extension)) = file_name.rsplit_once('.') else {
                 continue;
             };
             if !extensions.contains(&extension) {
                 continue;
             }
-            let Some(asset_id) = path.file_stem().and_then(|value| value.to_str()) else {
-                continue;
-            };
             if require_asset_id(asset_id).is_err() {
                 continue;
             }
             if asset_id != replaced_asset_id {
                 ids.insert(asset_id.to_string());
             }
-            if counts_bytes && path != replaced_asset_path {
-                let metadata = fs::symlink_metadata(&path)?;
+            let managed_path = managed_directory.join(format!("{asset_id}.{extension}"));
+            if counts_bytes && managed_path != replaced_asset_path {
+                let metadata = entry.metadata()?;
                 if metadata.is_file() && !metadata.file_type().is_symlink() {
                     bytes = bytes.saturating_add(metadata.len());
                 }
@@ -588,22 +603,32 @@ fn read_selected_file(path: &Path) -> Result<Vec<u8>, CommandError> {
 }
 
 fn read_regular_limited(path: &Path, limit: u64) -> Result<Vec<u8>, CommandError> {
+    read_regular_limited_with_hook(path, limit, || {})
+}
+
+fn read_regular_limited_with_hook(
+    path: &Path,
+    limit: u64,
+    before_open: impl FnOnce(),
+) -> Result<Vec<u8>, CommandError> {
     let visible = fs::symlink_metadata(path).map_err(|_| {
         CommandError::new(
             "background_image_unreadable",
             "the selected image could not be opened",
         )
     })?;
-    if visible.file_type().is_symlink() || !visible.is_file() || visible.len() > limit {
+    let invalid_file_type = visible.file_type().is_symlink() || !visible.is_file();
+    if invalid_file_type || visible.len() > limit {
         return Err(CommandError::new(
-            if visible.len() > limit {
-                "background_image_too_large"
-            } else {
+            if invalid_file_type {
                 "background_image_unreadable"
+            } else {
+                "background_image_too_large"
             },
             "the selected image must be a regular file within the size limit",
         ));
     }
+    before_open();
     let mut options = OpenOptions::new();
     options.read(true);
     #[cfg(unix)]
@@ -618,25 +643,52 @@ fn read_regular_limited(path: &Path, limit: u64) -> Result<Vec<u8>, CommandError
         )
     })?;
     let opened = file.metadata()?;
-    if !opened.is_file() || opened.len() != visible.len() || opened.len() > limit {
+    if !opened.is_file() || !same_file_identity(&visible, &opened) || opened.len() > limit {
         return Err(CommandError::new(
             "background_image_changed",
             "the selected image changed while it was being opened",
         ));
     }
     let mut bytes = Vec::with_capacity(opened.len() as usize);
-    file.take(limit + 1).read_to_end(&mut bytes)?;
+    (&file).take(limit + 1).read_to_end(&mut bytes)?;
     if bytes.len() as u64 > limit {
         return Err(CommandError::new(
             "background_image_too_large",
             "the selected image exceeds the size limit",
         ));
     }
+    let completed = file.metadata()?;
+    if !same_file_identity(&opened, &completed) || completed.len() != bytes.len() as u64 {
+        return Err(CommandError::new(
+            "background_image_changed",
+            "the selected image changed while it was being read",
+        ));
+    }
     Ok(bytes)
 }
 
-fn ensure_root(data_root: &Path) -> Result<PathBuf, CommandError> {
-    let root = data_root.join("backgrounds").join("v1");
+#[cfg(unix)]
+fn same_file_identity(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    left.dev() == right.dev()
+        && left.ino() == right.ino()
+        && left.len() == right.len()
+        && left.mtime() == right.mtime()
+        && left.mtime_nsec() == right.mtime_nsec()
+}
+
+#[cfg(not(unix))]
+fn same_file_identity(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    left.len() == right.len() && left.modified().ok() == right.modified().ok()
+}
+
+fn library_root(data_root: &Path) -> PathBuf {
+    data_root.join("backgrounds").join("v1")
+}
+
+fn ensure_root(data_root: &Path) -> Result<(), CommandError> {
+    let root = library_root(data_root);
     for path in [
         data_root.to_path_buf(),
         data_root.join("backgrounds"),
@@ -655,7 +707,7 @@ fn ensure_root(data_root: &Path) -> Result<PathBuf, CommandError> {
         }
         set_private_directory(&path)?;
     }
-    Ok(root)
+    Ok(())
 }
 
 fn asset_path_for_metadata(
@@ -721,13 +773,13 @@ fn persist_private_replacing(path: &Path, bytes: &[u8]) -> Result<(), CommandErr
         ));
     }
     let mut temporary = NamedTempFile::new_in(parent)?;
-    set_private_file(temporary.path())?;
+    set_private_file(temporary.as_file())?;
     temporary.write_all(bytes)?;
     temporary.as_file_mut().flush()?;
     temporary.as_file().sync_all()?;
     match temporary.persist(path) {
         Ok(file) => {
-            set_private_file(path)?;
+            set_private_file(&file)?;
             file.sync_all()?;
             let _ = File::open(parent).and_then(|directory| directory.sync_all());
             Ok(())
@@ -835,8 +887,20 @@ fn hex(bytes: &[u8]) -> String {
 
 #[cfg(unix)]
 fn set_private_directory(path: &Path) -> Result<(), CommandError> {
-    use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW);
+    let directory = options.open(path)?;
+    if !directory.metadata()?.is_dir() {
+        return Err(CommandError::new(
+            "background_library_unavailable",
+            "the private image library path is not a regular directory",
+        ));
+    }
+    directory.set_permissions(fs::Permissions::from_mode(0o700))?;
     Ok(())
 }
 
@@ -846,14 +910,15 @@ fn set_private_directory(_path: &Path) -> Result<(), CommandError> {
 }
 
 #[cfg(unix)]
-fn set_private_file(path: &Path) -> Result<(), CommandError> {
+fn set_private_file(file: &File) -> Result<(), CommandError> {
     use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(())
 }
 
 #[cfg(not(unix))]
-fn set_private_file(_path: &Path) -> Result<(), CommandError> {
+fn set_private_file(_file: &File) -> Result<(), CommandError> {
     Ok(())
 }
 
@@ -861,6 +926,11 @@ fn set_private_file(_path: &Path) -> Result<(), CommandError> {
 mod tests {
     use super::*;
     use image::ImageEncoder;
+
+    fn initialized_root(data_root: &Path) -> PathBuf {
+        ensure_root(data_root).unwrap();
+        library_root(data_root)
+    }
 
     fn test_png() -> Vec<u8> {
         let image = DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
@@ -909,7 +979,7 @@ mod tests {
     #[test]
     fn display_name_limit_is_120_unicode_scalars_in_import_and_metadata() {
         let directory = tempfile::tempdir().unwrap();
-        let root = ensure_root(directory.path()).unwrap();
+        let root = initialized_root(directory.path());
         let long_name = "图".repeat(MAX_DISPLAY_NAME_CHARS + 1);
         let displayed = display_name_for_path(Path::new(&format!("/tmp/{long_name}")));
         assert_eq!(displayed.chars().count(), MAX_DISPLAY_NAME_CHARS);
@@ -942,6 +1012,95 @@ mod tests {
         let error = import(directory.path(), Path::new("/does/not/exist")).unwrap_err();
         assert_eq!(error.code, "background_image_unreadable");
         assert!(decode_supported(b"GIF89a").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn regular_read_rejects_a_same_size_inode_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("selected.png");
+        let replacement = directory.path().join("replacement.png");
+        fs::write(&source, b"first").unwrap();
+        fs::write(&replacement, b"other").unwrap();
+
+        let error = read_regular_limited_with_hook(&source, 16, || {
+            fs::rename(&replacement, &source).unwrap();
+        })
+        .unwrap_err();
+
+        assert_eq!(error.code, "background_image_changed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn regular_read_rejects_a_symlink_without_touching_its_target() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let outside = directory.path().join("outside.png");
+        let selected = directory.path().join("selected.png");
+        fs::write(&outside, b"outside sentinel").unwrap();
+        symlink(&outside, &selected).unwrap();
+
+        let error = read_regular_limited(&selected, 64).unwrap_err();
+
+        assert_eq!(error.code, "background_image_unreadable");
+        assert_eq!(fs::read(&outside).unwrap(), b"outside sentinel");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_persist_replaces_a_symlink_without_chmodding_its_target() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let directory = tempfile::tempdir().unwrap();
+        let root = initialized_root(directory.path());
+        let destination = root.join("assets").join(format!("{}.png", "a".repeat(64)));
+        let outside = directory.path().join("outside-sentinel");
+        fs::write(&outside, b"keep outside").unwrap();
+        fs::set_permissions(&outside, fs::Permissions::from_mode(0o640)).unwrap();
+        let outside_mode = fs::metadata(&outside).unwrap().permissions().mode() & 0o777;
+        symlink(&outside, &destination).unwrap();
+
+        persist_private_replacing(&destination, b"managed copy").unwrap();
+
+        assert!(!fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(fs::read(&destination).unwrap(), b"managed copy");
+        assert_eq!(
+            fs::metadata(&destination).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(fs::read(&outside).unwrap(), b"keep outside");
+        assert_eq!(
+            fs::metadata(&outside).unwrap().permissions().mode() & 0o777,
+            outside_mode
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_root_rejects_a_symlinked_directory_without_chmodding_its_target() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let directory = tempfile::tempdir().unwrap();
+        let data_root = directory.path().join("app-data");
+        let outside = directory.path().join("outside-directory");
+        fs::create_dir(&data_root).unwrap();
+        fs::create_dir(&outside).unwrap();
+        fs::set_permissions(&outside, fs::Permissions::from_mode(0o750)).unwrap();
+        let outside_mode = fs::metadata(&outside).unwrap().permissions().mode() & 0o777;
+        symlink(&outside, data_root.join("backgrounds")).unwrap();
+
+        let error = ensure_root(&data_root).unwrap_err();
+
+        assert_eq!(error.code, "background_library_unavailable");
+        assert_eq!(
+            fs::metadata(&outside).unwrap().permissions().mode() & 0o777,
+            outside_mode
+        );
     }
 
     #[test]
@@ -1003,7 +1162,7 @@ mod tests {
     #[test]
     fn import_limits_count_every_managed_artifact_id() {
         let directory = tempfile::tempdir().unwrap();
-        let root = ensure_root(directory.path()).unwrap();
+        let root = initialized_root(directory.path());
         for index in 0..MAX_LIBRARY_ASSETS {
             let id = format!("{index:064x}");
             fs::write(root.join("metadata").join(format!("{id}.json")), b"broken").unwrap();
@@ -1019,7 +1178,7 @@ mod tests {
     #[test]
     fn import_counts_managed_asset_bytes_even_when_metadata_is_missing() {
         let directory = tempfile::tempdir().unwrap();
-        let root = ensure_root(directory.path()).unwrap();
+        let root = initialized_root(directory.path());
         let occupied_id = "b".repeat(64);
         let occupied = root.join("assets").join(format!("{occupied_id}.png"));
         File::create(occupied)
@@ -1040,7 +1199,7 @@ mod tests {
         let source = directory.path().join("repair-me.png");
         fs::write(&source, test_png()).unwrap();
         let first = import(directory.path(), &source).unwrap();
-        let root = ensure_root(directory.path()).unwrap();
+        let root = initialized_root(directory.path());
         let metadata_path = root.join("metadata").join(format!("{}.json", first.id));
         let asset_path = root.join("assets").join(format!("{}.png", first.id));
         let preview_path = root.join("previews").join(format!("{}.png", first.id));
@@ -1088,7 +1247,7 @@ mod tests {
         let source = directory.path().join("remove-me.png");
         fs::write(&source, test_png()).unwrap();
         let asset = import(directory.path(), &source).unwrap();
-        let root = ensure_root(directory.path()).unwrap();
+        let root = initialized_root(directory.path());
         let sentinel = root.join("metadata").join("keep-me.txt");
         fs::write(&sentinel, b"keep").unwrap();
 
@@ -1112,7 +1271,7 @@ mod tests {
         let source = directory.path().join("symlink-remove.png");
         fs::write(&source, test_png()).unwrap();
         let asset = import(directory.path(), &source).unwrap();
-        let root = ensure_root(directory.path()).unwrap();
+        let root = initialized_root(directory.path());
         let asset_path = root.join("assets").join(format!("{}.png", asset.id));
         let outside = directory.path().join("outside-sentinel");
         fs::write(&outside, b"keep outside").unwrap();
@@ -1130,7 +1289,7 @@ mod tests {
         let source = directory.path().join("retry-remove.png");
         fs::write(&source, test_png()).unwrap();
         let asset = import(directory.path(), &source).unwrap();
-        let root = ensure_root(directory.path()).unwrap();
+        let root = initialized_root(directory.path());
         let asset_path = root.join("assets").join(format!("{}.png", asset.id));
         let metadata_path = root.join("metadata").join(format!("{}.json", asset.id));
         let preview_path = root.join("previews").join(format!("{}.png", asset.id));
@@ -1179,7 +1338,7 @@ mod tests {
         fs::write(&source, test_png()).unwrap();
         let asset = import(directory.path(), &source).unwrap();
         let managed = resolve_asset_path(directory.path(), &asset.id).unwrap();
-        let private_root = ensure_root(directory.path()).unwrap();
+        let private_root = initialized_root(directory.path());
         let declaring_config = private_root.join("config");
 
         let quoted = format!("\"{}\"", managed.display());

--- a/src-tauri/src/domain/safe_write.rs
+++ b/src-tauri/src/domain/safe_write.rs
@@ -499,7 +499,7 @@ pub fn write_atomically(
     let prepared_replacement = prepare_replacement(target, candidate)?;
 
     let snapshot_id = Uuid::new_v4().to_string();
-    let snapshots = data_root.join("snapshots");
+    let snapshots = snapshot_directory(data_root);
     create_private_directory(&snapshots)?;
     // Make room before creating the new pair. This also prevents repeated
     // pre-commit conflicts from growing snapshot storage without bound.
@@ -581,23 +581,17 @@ pub fn write_atomically(
 }
 
 pub fn list_snapshots(data_root: &Path, target: &Path) -> Result<Vec<SnapshotInfo>, CommandError> {
-    let mut results = snapshot_records(data_root, target)?
-        .into_iter()
-        .map(|(snapshot, _)| snapshot)
-        .collect::<Vec<_>>();
+    let mut results = snapshot_records(data_root, target)?;
     results.sort_by_key(|snapshot| std::cmp::Reverse(snapshot.created_at_ms));
     results.truncate(MAX_SNAPSHOTS_PER_TARGET);
     Ok(results)
 }
 
-fn snapshot_records(
-    data_root: &Path,
-    target: &Path,
-) -> Result<Vec<(SnapshotInfo, std::path::PathBuf)>, CommandError> {
-    let snapshots = data_root.join("snapshots");
-    if !snapshots.exists() {
+fn snapshot_records(data_root: &Path, target: &Path) -> Result<Vec<SnapshotInfo>, CommandError> {
+    if !snapshot_directory_is_safe(data_root)? {
         return Ok(Vec::new());
     }
+    let snapshots = snapshot_directory(data_root);
     let expected_target_hash = path_hash(target);
     let mut results = Vec::new();
     for (index, entry) in fs::read_dir(snapshots)?.enumerate() {
@@ -620,7 +614,7 @@ fn snapshot_records(
         };
         let expected_file_name = format!("{}.json", snapshot.id);
         if snapshot.target_hash != expected_target_hash
-            || Uuid::parse_str(&snapshot.id).is_err()
+            || !is_canonical_snapshot_id(&snapshot.id)
             || path.file_name().and_then(|value| value.to_str()) != Some(&expected_file_name)
             || snapshot.created_at_ms == 0
             || snapshot.size_bytes > 4 * 1024 * 1024
@@ -628,15 +622,12 @@ fn snapshot_records(
         {
             continue;
         }
-        results.push((
-            SnapshotInfo {
-                id: snapshot.id,
-                created_at_ms: snapshot.created_at_ms,
-                revision: snapshot.revision,
-                size_bytes: snapshot.size_bytes,
-            },
-            path,
-        ));
+        results.push(SnapshotInfo {
+            id: snapshot.id,
+            created_at_ms: snapshot.created_at_ms,
+            revision: snapshot.revision,
+            size_bytes: snapshot.size_bytes,
+        });
     }
     Ok(results)
 }
@@ -647,10 +638,13 @@ fn prune_snapshots(
     preserve_snapshot_id: &str,
 ) -> Result<(), CommandError> {
     let mut records = snapshot_records(data_root, target)?;
-    records.sort_by_key(|(snapshot, _)| std::cmp::Reverse(snapshot.created_at_ms));
-    let snapshots = data_root.join("snapshots");
+    records.sort_by_key(|snapshot| std::cmp::Reverse(snapshot.created_at_ms));
+    if !snapshot_directory_is_safe(data_root)? {
+        return Ok(());
+    }
+    let snapshots = snapshot_directory(data_root);
     let mut retained_other_snapshots = 0_usize;
-    for (snapshot, metadata_path) in records {
+    for snapshot in records {
         if snapshot.id == preserve_snapshot_id {
             continue;
         }
@@ -659,6 +653,7 @@ fn prune_snapshots(
             continue;
         }
         let content_path = snapshots.join(format!("{}.ghostty", snapshot.id));
+        let metadata_path = snapshots.join(format!("{}.json", snapshot.id));
         match fs::symlink_metadata(&content_path) {
             Ok(metadata)
                 if metadata.file_type().is_file() && !metadata.file_type().is_symlink() =>
@@ -674,7 +669,7 @@ fn prune_snapshots(
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(error) => return Err(error.into()),
         }
-        fs::remove_file(metadata_path)?;
+        fs::remove_file(&metadata_path)?;
     }
     File::open(snapshots)?.sync_all()?;
     Ok(())
@@ -685,10 +680,19 @@ pub fn read_snapshot(
     target: &Path,
     snapshot_id: &str,
 ) -> Result<Vec<u8>, CommandError> {
-    Uuid::parse_str(snapshot_id).map_err(|_| {
-        CommandError::new("invalid_snapshot_id", "snapshot id must be a valid UUID")
-    })?;
-    let snapshots = data_root.join("snapshots");
+    if !is_canonical_snapshot_id(snapshot_id) {
+        return Err(CommandError::new(
+            "invalid_snapshot_id",
+            "snapshot id must be a canonical UUID",
+        ));
+    }
+    if !snapshot_directory_is_safe(data_root)? {
+        return Err(CommandError::new(
+            "unknown_snapshot",
+            "snapshot storage is unavailable",
+        ));
+    }
+    let snapshots = snapshot_directory(data_root);
     let metadata_path = snapshots.join(format!("{snapshot_id}.json"));
     let content_path = snapshots.join(format!("{snapshot_id}.ghostty"));
     let metadata_bytes = read_regular_snapshot_file(&metadata_path, 64 * 1024)?;
@@ -962,6 +966,30 @@ fn is_revision(value: &str) -> bool {
     value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
+fn is_canonical_snapshot_id(value: &str) -> bool {
+    Uuid::parse_str(value).is_ok_and(|uuid| uuid.hyphenated().to_string() == value)
+}
+
+fn snapshot_directory(data_root: &Path) -> std::path::PathBuf {
+    data_root.join("snapshots")
+}
+
+fn snapshot_directory_is_safe(data_root: &Path) -> Result<bool, CommandError> {
+    let snapshots = snapshot_directory(data_root);
+    let metadata = match fs::symlink_metadata(&snapshots) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() || !metadata.file_type().is_dir() {
+        return Err(CommandError::new(
+            "invalid_private_directory",
+            "snapshot storage path is not a regular directory",
+        ));
+    }
+    Ok(true)
+}
+
 fn hex(bytes: &[u8]) -> String {
     bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
@@ -1162,6 +1190,29 @@ mod tests {
         fs::write(&target, b"font-size = 13\n").unwrap();
         let error = read_snapshot(directory.path(), &target, "../../secret").unwrap_err();
         assert_eq!(error.code, "invalid_snapshot_id");
+        let noncanonical = Uuid::new_v4().simple().to_string();
+        let error = read_snapshot(directory.path(), &target, &noncanonical).unwrap_err();
+        assert_eq!(error.code, "invalid_snapshot_id");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn snapshot_storage_refuses_a_symlinked_root() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let data_root = directory.path().join("data");
+        let outside = directory.path().join("outside");
+        let target = directory.path().join("config");
+        fs::create_dir_all(&data_root).unwrap();
+        fs::create_dir(&outside).unwrap();
+        fs::write(&target, b"font-size = 13\n").unwrap();
+        fs::write(outside.join("canary"), b"keep").unwrap();
+        symlink(&outside, snapshot_directory(&data_root)).unwrap();
+
+        let error = list_snapshots(&data_root, &target).unwrap_err();
+        assert_eq!(error.code, "invalid_private_directory");
+        assert_eq!(fs::read(outside.join("canary")).unwrap(), b"keep");
     }
 
     #[cfg(unix)]

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -1,0 +1,59 @@
+// @ts-expect-error Vitest executes this contract test in Node; the app bundle intentionally omits Node types.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  new URL("../.github/workflows/release-candidate.yml", import.meta.url),
+  "utf8",
+);
+
+function indentedBlock(source: string, header: string): string {
+  const lines = source.split("\n");
+  const start = lines.findIndex((line) => line === header);
+  expect(start, `missing workflow block: ${header.trim()}`).toBeGreaterThanOrEqual(0);
+
+  const indentation = header.length - header.trimStart().length;
+  let end = start + 1;
+  while (end < lines.length) {
+    const line = lines[end];
+    if (line.trim() && line.length - line.trimStart().length <= indentation) break;
+    end += 1;
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+describe("release candidate workflow contract", () => {
+  it("accepts only a version input and never sends an input ref to checkout", () => {
+    const dispatch = indentedBlock(workflow, "  workflow_dispatch:");
+    const inputs = indentedBlock(dispatch, "    inputs:");
+    const inputNames = [...inputs.matchAll(/^ {6}([A-Za-z_][A-Za-z0-9_-]*):(?:\s|$)/gm)].map(
+      ([, name]) => name,
+    );
+
+    expect(inputNames).toEqual(["version"]);
+    expect(workflow).not.toContain("inputs.ref");
+
+    const checkoutSteps = workflow.match(/^ {6}- uses: actions\/checkout@.*$/gm) ?? [];
+    expect(checkoutSteps).toHaveLength(1);
+    const checkout = indentedBlock(workflow, checkoutSteps[0]);
+    expect(checkout).toContain("persist-credentials: false");
+    expect(checkout).not.toMatch(/^\s+ref:/m);
+  });
+
+  it("fails closed unless the dispatch ref is protected main", () => {
+    const protectedSource = indentedBlock(workflow, "  protected-source:");
+
+    expect(protectedSource).toContain("SOURCE_REF: ${{ github.ref }}");
+    expect(protectedSource).toContain('if [[ "$SOURCE_REF" != "refs/heads/main" ]]; then');
+    expect(protectedSource).toMatch(/if \[\[ "\$SOURCE_REF" != "refs\/heads\/main" \]\]; then[\s\S]*?\n\s+exit 1/);
+  });
+
+  it("keeps packaging behind the protected-source gate with read-only access", () => {
+    const permissions = indentedBlock(workflow, "permissions:");
+    const macosJob = indentedBlock(workflow, "  macos-arm64:");
+
+    expect(permissions.trim()).toBe("permissions:\n  contents: read");
+    expect(macosJob).toMatch(/^ {4}needs: protected-source$/m);
+    expect(macosJob).toContain('if [[ "$checked_out_sha" != "$GITHUB_SHA" ]]; then');
+  });
+});


### PR DESCRIPTION
## What changed

- bind private image reads to one Unix file identity across lstat, open, and read
- set private image and directory permissions through no-follow file descriptors
- validate managed asset names before rebuilding paths from directory entries
- rebuild snapshot cleanup paths from canonical UUIDs and reject symlinked snapshot roots
- restrict release candidates to the protected `main` event SHA and add a workflow contract test

## Why

The first repository-wide CodeQL run surfaced one genuine candidate-provenance issue, one path-based permission race, and several path flows whose safety depended on validations the analyzer could not follow. This change removes the real races and makes the remaining authority boundaries explicit without exposing paths to the WebView or weakening adversarial tests.

## Verification

- `pnpm check`
- frontend: 25 files, 120 tests
- Rust: 114 tests
- TypeScript and Vite production build
- site build
- Rust fmt and Clippy with warnings denied
- changed-file credential and local-path scan

No installer or GitHub Release is created by this change.
