### PR TITLE
deps: update base64 without SIMD unsafe

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -95,6 +95,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,7 +1063,7 @@ dependencies = [
 name = "ghostty-studio"
 version = "0.4.0"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "fs2",
  "image",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-base64 = "0.22.1"
+base64 = { version = "0.23.1", default-features = false, features = ["std"] }
 fs2 = "0.4"
 image = { version = "0.25.10", default-features = false, features = ["jpeg", "png"] }
 libc = "0.2"


### PR DESCRIPTION
## What changed

- update the direct `base64` dependency to 0.23.1
- disable default features and enable only `std`
- retain transitive `base64` 0.22.1 where existing dependencies still require it

## Why

base64 0.23 enables `simd-unsafe` by default. Ghostty Studio only uses standard Base64 encoding for preview data URLs, so enabling that additional unsafe implementation surface provides no product benefit.

This safely supersedes #8.

## Validation

- `cargo tree -i base64@0.23.1 -e features` confirms only `alloc` and `std`
- `pnpm check`
- 121 frontend tests
- 114 Rust tests
- Clippy with warnings denied
- production app and site builds
- `git diff --check`