### PR TITLE
deps: migrate executable hashing to sha2 0.11

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -140,6 +140,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +412,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +452,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -562,8 +589,18 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1071,7 +1108,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -1306,6 +1343,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2821,8 +2867,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3171,7 +3228,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.119",
  "tauri-utils",
  "thiserror 2.0.19",
@@ -4554,7 +4611,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.19",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1"
-sha2 = "0.10"
+sha2 = { version = "0.11", default-features = false }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "=2.7.2"
 tempfile = "3"

--- a/src-tauri/src/domain/ghostty.rs
+++ b/src-tauri/src/domain/ghostty.rs
@@ -72,11 +72,17 @@ impl ExecutableIdentity {
         require_bounded_regular_executable(&before)?;
 
         let mut digest = Sha256::new();
-        let bytes_read = std::io::copy(
-            &mut file.by_ref().take(MAX_EXECUTABLE_BYTES.saturating_add(1)),
-            &mut digest,
-        )
-        .map_err(identity_io_error)?;
+        let mut reader = file.by_ref().take(MAX_EXECUTABLE_BYTES.saturating_add(1));
+        let mut buffer = [0_u8; 64 * 1024];
+        let mut bytes_read = 0_u64;
+        loop {
+            let read = reader.read(&mut buffer).map_err(identity_io_error)?;
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
+            bytes_read = bytes_read.saturating_add(read as u64);
+        }
         if bytes_read != before.len() || bytes_read > MAX_EXECUTABLE_BYTES {
             return Err(CommandError::new(
                 "ghostty_identity_unavailable",


### PR DESCRIPTION
## What changed

- update the direct `sha2` dependency to 0.11 with default features disabled
- replace the removed `std::io::Write` adapter with a bounded 64 KiB read loop using `Digest::update`
- retain sha2 0.10.9 transitively where Tauri still requires it

## Why

The original Dependabot update in #10 no longer compiles against the executable identity code because `Sha256` in sha2 0.11 does not implement `std::io::Write`. This migration adopts the new API without weakening the executable identity checks.

The reader still consumes at most `MAX_EXECUTABLE_BYTES + 1`, verifies the exact byte count, and compares file identity before and after hashing.

This safely supersedes #10.

## Validation

- frozen pnpm install using Vitest 4.1.10, Lucide 1.28.0, and TypeScript 7.0.2
- `pnpm check`
- 121 frontend tests
- 114 Rust tests, including executable identity coverage
- Clippy with warnings denied
- production app and site builds
- `git diff --check`