### PR TITLE
a11y: expose the search escape shortcut

### DIFF
--- a/src/app-journey.test.tsx
+++ b/src/app-journey.test.tsx
@@ -331,7 +331,7 @@ describe("primary application journey", () => {
     });
 
     const resultStatus = container.querySelector<HTMLElement>("#search-result-count")!;
-    expect(search.getAttribute("aria-keyshortcuts")).toBe("Meta+K Control+K");
+    expect(search.getAttribute("aria-keyshortcuts")).toBe("Meta+K Control+K Escape");
     expect(search.getAttribute("aria-describedby")).toBe("search-result-count");
     expect(resultStatus.getAttribute("role")).toBe("status");
     expect(resultStatus.getAttribute("aria-live")).toBe("polite");
@@ -361,6 +361,7 @@ describe("primary application journey", () => {
 
     expect(search.value).toBe("");
     expect(document.activeElement).toBe(search);
+    expect(search.getAttribute("aria-keyshortcuts")).toBe("Meta+K Control+K");
     expect(search.hasAttribute("aria-describedby")).toBe(false);
     expect(container.querySelector("#search-result-count")).toBeNull();
   });

--- a/src/components/StudioSidebar.tsx
+++ b/src/components/StudioSidebar.tsx
@@ -110,7 +110,9 @@ export function StudioSidebar({
             ? searchLabel
             : text("打开配置后即可搜索", "Open a configuration to search")}
           aria-label={searchLabel}
-          aria-keyshortcuts={workspaceReady ? "Meta+K Control+K" : undefined}
+          aria-keyshortcuts={workspaceReady
+            ? `Meta+K Control+K${search ? " Escape" : ""}`
+            : undefined}
           aria-describedby={workspaceReady && search ? "search-result-count" : undefined}
         />
         {workspaceReady && search ? (


### PR DESCRIPTION
## What changed

- announce `Escape` through `aria-keyshortcuts` while the settings search contains a query
- return the shortcut metadata to Command/Ctrl-K after the query is cleared
- cover both states in the application journey test

## Why

The search already supports Escape to clear the active query, but assistive technology could not discover that shortcut. This keeps the interface unchanged while making the existing behavior explicit.

## Validation

- `pnpm exec vitest run src/app-journey.test.tsx` — 18 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm check:web` under Node 22.21.0 — build, 121 tests, and site build passed
- `git diff --cached --check`
